### PR TITLE
Unpin scalatags-0.10

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,4 +1,0 @@
-updates.pin = [
-  # scalatags-0.11 breaks bincompat
-  { groupId = "com.lihaoyi", artifactId = "scalatags", version = "0.10." }
-]


### PR DESCRIPTION
That was necessary only on the 0.23 series.  The 0.24 series is so this project can get current.