### PR TITLE
Add doctype encoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ tags
 .bloop/
 metals.sbt
 .vscode
+null/
 
 # npm
 node_modules/

--- a/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
+++ b/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
@@ -36,16 +36,16 @@ trait ScalatagsInstances {
       .contramap[C](content => content.render)
       .withContentType(`Content-Type`(mediaType, charset))
 
-  implicit def doctypeEncoder[F[_], C <: doctype](implicit
+  implicit def doctypeEncoder[F[_](implicit
       charset: Charset = `UTF-8`
-  ): EntityEncoder[F, C] =
-    contentEncoder2(MediaType.text.html)
+  ): EntityEncoder[F, doctype] =
+    doctypeContentEncoder(MediaType.text.html)
 
-  private def contentEncoder2[F[_], C <: doctype](
+  private def doctypeContentEncoder[F[_]](
       mediaType: MediaType
-  )(implicit charset: Charset): EntityEncoder[F, C] =
+  )(implicit charset: Charset): EntityEncoder[F, doctype] =
     EntityEncoder
       .stringEncoder[F]
-      .contramap[C](content => content.render)
+      .contramap[doctype](content => content.render)
       .withContentType(`Content-Type`(mediaType, charset))
 }

--- a/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
+++ b/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
@@ -17,8 +17,8 @@
 package org.http4s
 package scalatags
 
-import _root_.scalatags.generic.Frag
 import _root_.scalatags.Text.all.doctype
+import _root_.scalatags.generic.Frag
 import org.http4s.Charset.`UTF-8`
 import org.http4s.headers.`Content-Type`
 

--- a/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
+++ b/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
@@ -18,6 +18,7 @@ package org.http4s
 package scalatags
 
 import _root_.scalatags.generic.Frag
+import _root_.scalatags.Text.all.doctype
 import org.http4s.Charset.`UTF-8`
 import org.http4s.headers.`Content-Type`
 
@@ -28,6 +29,19 @@ trait ScalatagsInstances {
     contentEncoder(MediaType.text.html)
 
   private def contentEncoder[F[_], C <: Frag[_, String]](
+      mediaType: MediaType
+  )(implicit charset: Charset): EntityEncoder[F, C] =
+    EntityEncoder
+      .stringEncoder[F]
+      .contramap[C](content => content.render)
+      .withContentType(`Content-Type`(mediaType, charset))
+
+  implicit def doctypeEncoder[F[_], C <: doctype](implicit
+      charset: Charset = `UTF-8`
+  ): EntityEncoder[F, C] =
+    contentEncoder2(MediaType.text.html)
+
+  private def contentEncoder2[F[_], C <: doctype](
       mediaType: MediaType
   )(implicit charset: Charset): EntityEncoder[F, C] =
     EntityEncoder

--- a/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
+++ b/scalatags/src/main/scala/org/http4s/scalatags/ScalatagsInstances.scala
@@ -36,7 +36,7 @@ trait ScalatagsInstances {
       .contramap[C](content => content.render)
       .withContentType(`Content-Type`(mediaType, charset))
 
-  implicit def doctypeEncoder[F[_](implicit
+  implicit def doctypeEncoder[F[_]](implicit
       charset: Charset = `UTF-8`
   ): EntityEncoder[F, doctype] =
     doctypeContentEncoder(MediaType.text.html)

--- a/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSuite.scala
+++ b/scalatags/src/test/scala/org/http4s/scalatags/ScalatagsSuite.scala
@@ -92,6 +92,10 @@ class ScalatagsSuite extends CatsEffectSuite {
       .text[IO]
       .decode(resp, strict = false)
       .value
-      .assertEquals(Right("<!DOCTYPE html><html lang=\"en\"><head><title>http4s-scalatags</title></head><body><div><p>this is my testBody</p></div></body></html>"))
+      .assertEquals(
+        Right(
+          "<!DOCTYPE html><html lang=\"en\"><head><title>http4s-scalatags</title></head><body><div><p>this is my testBody</p></div></body></html>"
+        )
+      )
   }
 }


### PR DESCRIPTION
@armanbilge As you can see there is duplicate code, but I don't currently know how to fix that ...

Fixes: https://github.com/http4s/http4s-scalatags/issues/44

I'm not really happy with this code. It should work, but it seems clunky. The http4s documentation on encoders is just terrible :( Why can't I just tell http4s that if it receives this type or this type do to this. How does it even get the function which matches. So many unknowns here.